### PR TITLE
Small updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,20 @@ This repo is meant as an example regarding workflows and IPKs.
 
 The `Makefile` is used to build an IPK from the available `control` and `data` directories. The `automation.yml` workflow file is meant to create a new release as soon as a new tag is pushed to the repository.
 
-> It will thus trigger building the IPK, create a release and attaching the IPK to itt.
+> It will thus trigger building the IPK, create a release and attaching the IPK to it.
+
+## Control
+The `control` directory contains the `control` file, which is used to define the package name, version, maintainer, dependencies and so on.
+the `Architecture` field can have the following values:
+- `all` - the package is architecture independent
+- `pigeon-all` - all pigeon architectures
+- `pigeon-glasses` - only goggles
+- `pigeon-glasses-v1` - only goggles v1
+- `pigeon-glasses-v2` - only goggles v2
+- `pigeon-airside` - only airside
+- `pigeon-airside-au` - only air units
+- `pigeon-airside-lite` - only vistas
+- `armv7-3.2` - the package is only for the armv7 architecture
 
 ## Workflow
 Check [automation.yml](./.github/workflows/automation.yml) this file should be pretty self explanatory, there are two jobs: **build** and **release**.


### PR DESCRIPTION
Moved `bin` from `data/bin` to `data/opt/bin`
Any files inside the old bin folder location couldn't be found on the device after IPK install, moving directories solved this resulting in files going into the `/opt/bin` directory on the device

Added some clarification to what the possible values can be for `Architecture` in the control file